### PR TITLE
lanyrd REST endpoint schedule data access 

### DIFF
--- a/lanyrd.js
+++ b/lanyrd.js
@@ -1,8 +1,11 @@
 var request = require('request')
 var getRows = function(rows){
   var merged = [];
-  for(var i=0; i<rows.length; i++) {
-    merged = merged.concat(rows[i]['rows']);
+  if ( typeof rows !== 'undefined' && rows )
+  {
+	  for(var i=0; i<rows.length; i++) {
+		merged = merged.concat(rows[i]['rows']);
+	  }
   }
   return merged
 }
@@ -46,6 +49,11 @@ var Lanyrd = {
       cb(error, response, getRows(body['sections']))
     })
   },
+  scheduleDetail: function (date, slug, year, cb){
+	this.get(year +'/' + slug + '/schedule/' + date, function(error, response, body){
+      cb(error, response, getRows(body['sections']))
+    })
+  },  
   profile: function (username, cb){
     this.get('profile/' + username + '/', function(error, response, body){
       cb(error, response, body)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ]
   "name": "lanyrd",
   "description": "Unoffical Lanyrd API client",
-  "version": "0.3.1",
+  "version": "0.2.1",
   "homepage": "https://github.com/andrew/node-lanyrd",
   "keywords": [
     "lanyrd",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Nesbitt <andrewnez@gmail.com> (http://andrew.github.io)",
   "contributors": [
 	"André Langer <andre.langer@googlemail.com> (http://www.andré-langer.de/)"
-  ]
+  ],
   "name": "lanyrd",
   "description": "Unoffical Lanyrd API client",
   "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "author": "Andrew Nesbitt <andrewnez@gmail.com> (http://andrew.github.io)",
+  "contributors": [
+	"André Langer <andre.langer@googlemail.com> (http://www.andré-langer.de/)"
+  ]
   "name": "lanyrd",
   "description": "Unoffical Lanyrd API client",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "homepage": "https://github.com/andrew/node-lanyrd",
   "keywords": [
     "lanyrd",


### PR DESCRIPTION
the lanyrd rest endpoint was lately modified and schedule details such as the date and room number can now only be accessed through a date-specific url